### PR TITLE
Backwards compatible changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ _wide.*.so
 build
 dist
 .cache
-.hypothesis

--- a/README.rst
+++ b/README.rst
@@ -34,3 +34,31 @@ all the products of the subcomponents up to permutation of columns:
                 wide_product(A, D),
                 wide_product(B, C),
                 wide_product(B, D)))
+
+Installation
+------------
+
+.. code:: bash
+
+  pip install wide-product
+
+Development
+-----------
+
+To build the module:
+
+.. code:: bash
+
+  python setup.py build
+
+To test:
+
+.. code:: bash
+
+  PYTHONPATH=$(echo build/lib*):. py.test
+
+To install:
+
+.. code:: bash
+
+  pip install .

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author="Thread Tech",
     author_email="tech@thread.com",
 
-    keywords = (
+    keywords=(
         'numpy',
         'scipy',
         'matrix',

--- a/tests/test_wide.py
+++ b/tests/test_wide.py
@@ -97,4 +97,6 @@ def test_horizontal_stacking(a_width, b_width, height_top, height_bottom, data):
 
     full_product = wide_product(a, b)
 
-    assert full_product == stacked_product
+    x = (full_product != stacked_product).todense().ravel()
+
+    assert not numpy.any(x)

--- a/tests/test_wide.py
+++ b/tests/test_wide.py
@@ -46,7 +46,7 @@ def get_sparse_matrix(shape, data):
     )), dtype='int32')
 
     return scipy.sparse.coo_matrix(
-        (element_data, locations[:, 0], locations[:, 1]),
+        (element_data, (locations[:, 0], locations[:, 1])),
         shape=shape,
     ).tocsr()
 


### PR DESCRIPTION
Looks like we were constructing COO matrices in a way that my scipy version didn't understand, and also comparing results. I've changed both of these so they work with older versions of scipy but not sure about the quality of the test change - can you advise?

Otherwise, ran this on ~1m examples and all looks good. Thanks! I'll add how to build/test/examples to the README and put it up on pypi.